### PR TITLE
Add Cheats

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -77,9 +77,19 @@ void retro_cheat_reset()
     // Empty
 }
 
-void retro_cheat_set(unsigned /*index*/, bool /*enabled*/, const char */*code*/)
+void retro_cheat_set(unsigned index, bool enabled, const char *code)
 {
-    // Empty
+    if (enabled) {
+        std::string code_string(code);
+        if (code_string == "next") {
+            event::push(event::Event(true, 'N'));
+            debug_print("puzzlescript: Cheat: Next Level\n");
+        }
+        else if (code_string == "previous") {
+            event::push(event::Event(true, 'P'));
+            debug_print("puzzlescript: Cheat: Previous Level\n");
+        }
+    }
 }
 
 void update_variables()


### PR DESCRIPTION
This adds a retro_cheat_set() implementation that allows triggering the 'N' and 'P' events when entered. It requires this cheats file that I'm happy to add to the cheats db.

```
# PuzzleScript Cheats

cheats = 2

cheat0_desc = "Next Level"
cheat0_code = "next"
cheat0_enable = false

cheat1_desc = "Previous Level"
cheat1_code = "previous"
cheat1_enable = false
```
