### PR TITLE
ci: Make gitlab get the git submodules

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,7 @@
 # Core definitions
 .core-defs:
   variables:
+    GIT_SUBMODULE_STRATEGY: recursive
     JNI_PATH: .
     CORENAME: puzzlescript
     MAKEFILE: Makefile


### PR DESCRIPTION
This adds `GIT_SUBMODULE_STRATEGY` to have Gitlab's CI retrieve the submodules