### PR TITLE
Address dingux fixes with std::abs and casing the input key

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -369,7 +369,7 @@ void retro_run()
     for (auto const & binding : joypad_keys) {
         auto const & key{binding.first};
         auto const & val{binding.second};
-        if (!joypad_old_state[key] && input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, key)) {
+        if (!joypad_old_state[(int)key] && input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, key)) {
             if (key == RETRO_DEVICE_ID_JOYPAD_LEFT) {
                 // Check for SELECT cheatcodes
                 if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT)) {

--- a/src/generator.cpp
+++ b/src/generator.cpp
@@ -79,7 +79,7 @@ std::vector<float> Generator::generate()
     {
         fdphase = -fdphase;
     }
-    iphase = abs((int)fphase);
+    iphase = std::abs((int)fphase);
     ipp = 0;
     for (int i = 0; i < 1024; i++) 
     {
@@ -180,7 +180,7 @@ std::vector<float> Generator::generate()
 
         // Phaser step
         fphase += fdphase;
-        iphase = abs(static_cast<int>(fphase));
+        iphase = std::abs(static_cast<int>(fphase));
         if (iphase > 1023) iphase = 1023;
 
         if (flthp_d != 0.0f)


### PR DESCRIPTION
```
/opt/gcw0-toolchain/usr/bin/mipsel-linux-g++  -c -osrc/graphics.o src/graphics.cpp -fno-rtti -std=gnu++11 -DGIT_VERSION=\"" "\" -O2 -DNDEBUG -DUSE_PRECOMPILED_BUNDLE -pthread -std=c++11 -fno-rtti -fPIC -D__LIBRETRO__ -ffast-math -march=mips32 -mtune=mips32r2 -mhard-float -fomit-frame-pointer   -DNST_NO_ZLIB -I./src -I./src/libretro -I./src/quickjs  -I. -I./src
src/generator.cpp: In member function 'std::vector<float> Generator::generate()':
src/generator.cpp:82:29: error: 'abs' was not declared in this scope
     iphase = abs((int)fphase);
                             ^
src/generator.cpp:82:29: note: suggested alternative:
In file included from src/generator.cpp:3:0:
/opt/gcw0-toolchain/usr/mipsel-gcw0-linux-uclibc/include/c++/4.9.1/cmath:99:5: note:   'std::abs'
     abs(_Tp __x)
     ^
make: *** [Makefile:775: src/generator.o] Error 1
make: *** Waiting for unfinished jobs....
src/core.cpp: In function 'void retro_run()':
src/core.cpp:372:30: error: no match for 'operator[]' (operand types are 'std::map<int, bool>' and 'const std::initializer_list<const int>')
         if (!joypad_old_state[key] && input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, key)) {
                              ^
src/core.cpp:372:30: note: candidates are:
In file included from /opt/gcw0-toolchain/usr/mipsel-gcw0-linux-uclibc/include/c++/4.9.1/map:61:0,
                 from src/core.cpp:6:
/opt/gcw0-toolchain/usr/mipsel-gcw0-linux-uclibc/include/c++/4.9.1/bits/stl_map.h:491:7: note: std::map<_Key, _Tp, _Compare, _Alloc>::mapped_type& std::map<_Key, _Tp, _Compare, _Alloc>::operator[](const key_type&) [with _Key = int; _Tp = bool; _Compare = std::less<int>; _Alloc = std::allocator<std::pair<const int, bool> >; std::map<_Key, _Tp, _Compare, _Alloc>::mapped_type = bool; std::map<_Key, _Tp, _Compare, _Alloc>::key_type = int]
       operator[](const key_type& __k)
       ^
```
