### PR TITLE
dingux: Use our own fenv.h for QuickJS

### DIFF
--- a/src/fenv.h
+++ b/src/fenv.h
@@ -1,0 +1,33 @@
+/**
+ * PuzzleScript fenv.h
+ * 
+ * Override's QuickJS's usage of fenv.h so that we don't require linking it directly.
+ * 
+ * This aims to address `libretro-build-dingux-odbeta-mips32` build errors.
+ */
+
+#ifndef PUZZLESCRIPT_SRC_FENV_H__
+#define PUZZLESCRIPT_SRC_FENV_H__
+
+#define FE_INVALID    0x01
+#define FE_DIVBYZERO  0x02
+#define FE_OVERFLOW   0x04
+#define FE_UNDERFLOW  0x08
+#define FE_INEXACT    0x10
+#define FE_DENORMAL   0x80
+#define FE_ALL_EXCEPT (FE_DIVBYZERO | FE_INEXACT | FE_INVALID | FE_OVERFLOW | FE_UNDERFLOW | FE_DENORMAL)
+#define FE_TONEAREST  0x0
+#define FE_UPWARD     0x1
+#define FE_DOWNWARD   0x2
+#define FE_TOWARDZERO 0x3
+
+/**
+ * Our own implementation of fesetround() to override how QuickJS handles setting the float-rounding.
+ * 
+ * @see quickjs.c
+ */
+int fesetround(int /* value */) {
+    return 0;
+}
+
+#endif


### PR DESCRIPTION
This change aims to address `libretro-build-dingux-odbeta-mips32`...

```
/opt/gcw0-toolchain/usr/bin/mipsel-linux-gcc  -c -osrc/quickjs/quickjs.o src/quickjs/quickjs.c -std=gnu11 -DGIT_VERSION=\"" "\" -O2 -DNDEBUG -D_GNU_SOURCE -DCONFIG_VERSION=\"2024-01-13\" -lpthread -fPIC -D__LIBRETRO__ -ffast-math -march=mips32 -mtune=mips32r2 -mhard-float -fomit-frame-pointer   -DNST_NO_ZLIB -I./src -I./src/libretro/include -I./src/quickjs  -std=gnu99 -I. -I./src
src/quickjs/quickjs.c:33:10: fatal error: fenv.h: No such file or directory
   33 | #include <fenv.h>
      |          ^~~~~~~~
```

QuickJS includes this file for the defines and fesetround(), so this change implements our own version of it so that mip32 should build okay. This is a big ugly hack, and I'm not entirely sure of any floating-point rounding consequences of it, but games seem to be running okay.
