### PR TITLE
fenv: Include the rounding mode

### DIFF
--- a/src/fenv.h
+++ b/src/fenv.h
@@ -26,7 +26,7 @@
  * 
  * @see quickjs.c
  */
-int fesetround(int /* value */) {
+int fesetround(int rounding_mode) {
     return 0;
 }
 


### PR DESCRIPTION
@nwhitehead I broke all the builds, apologies about that...

```
In file included from src/quickjs/quickjs.c:33:
./src/fenv.h:29:31: error: parameter name omitted
int fesetround(int /* value */) {
                              ^
```