### PR TITLE
Add basic configure script to allow standard make builds

### DIFF
--- a/configure
+++ b/configure
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# This ./configure file is set up to allow use of the standard make build practices.
+
+PACKAGE_NAME=pzretro


### PR DESCRIPTION
This doesn't do anything, but does make it so that in standard build practices, the configure task doesn't break.
