### PR TITLE
Use libretro_core_options instead of SET_VARIABLES

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "libretro.h"
+#include "libretro_core_options.h"
 
 #include "audio.h"
 #include "event.h"
@@ -83,7 +84,7 @@ void retro_cheat_set(unsigned index, bool enabled, const char *code)
         std::string code_string(code);
         if (code_string == "next") {
             event::push(event::Event(true, 'N'));
-            debug_print("puzzlescript: Cheat: Next Level\n");
+            debug_print("puzzlescript: Cheat: Next Level\n"); 
         }
         else if (code_string == "previous") {
             event::push(event::Event(true, 'P'));
@@ -221,16 +222,6 @@ bool retro_unserialize(const void *data, size_t size)
     }
 }
 
-namespace { // anonymous
-
-struct retro_variable variables[] = {
-    { "pzretro_custom_font", "Use custom anti-aliased font; off|on" },
-    { "pzretro_use_puzzlescript_plus", "Use extended PuzzleScriptPlus engine; off|on" },
-    { NULL, NULL },
-};
-
-} // anonymous
-
 void retro_set_environment(retro_environment_t cb)
 {
     environ_cb = cb;
@@ -239,7 +230,8 @@ void retro_set_environment(retro_environment_t cb)
     bool no_rom = true;
     cb(RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME, &no_rom);
 
-    cb(RETRO_ENVIRONMENT_SET_VARIABLES, variables);
+    // Set up the core options, which are retrieved with update_variables().
+    libretro_set_core_options(cb);
 }
 
 void retro_set_audio_sample_batch(retro_audio_sample_batch_t cb)

--- a/src/libretro_core_options.h
+++ b/src/libretro_core_options.h
@@ -1,0 +1,258 @@
+#ifndef SRC_LIBRETRO_CORE_OPTIONS_H_
+#define SRC_LIBRETRO_CORE_OPTIONS_H_
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <libretro.h>
+#include <retro_inline.h>
+
+#ifndef HAVE_NO_LANGEXTRA
+#include "libretro_core_options_intl.h"
+#endif
+
+/*
+ ********************************
+ * VERSION: 1.3
+ ********************************
+ *
+ * - 1.3: Move translations to libretro_core_options_intl.h
+ *        - libretro_core_options_intl.h includes BOM and utf-8
+ *          fix for MSVC 2010-2013
+ *        - Added HAVE_NO_LANGEXTRA flag to disable translations
+ *          on platforms/compilers without BOM support
+ * - 1.2: Use core options v1 interface when
+ *        RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION is >= 1
+ *        (previously required RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION == 1)
+ * - 1.1: Support generation of core options v0 retro_core_option_value
+ *        arrays containing options with a single value
+ * - 1.0: First commit
+*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ ********************************
+ * Core Option Definitions
+ ********************************
+*/
+
+/* RETRO_LANGUAGE_ENGLISH */
+
+/* Default language:
+ * - All other languages must include the same keys and values
+ * - Will be used as a fallback in the event that frontend language
+ *   is not available
+ * - Will be used as a fallback for any missing entries in
+ *   frontend language definition */
+
+struct retro_core_option_definition option_defs_us[] = {
+	{
+		"pzretro_custom_font",
+		"Anti-Aliased Font",
+		"Use the custom anti-aliased font. Can have an impact on performance. Requires a restart.",
+		{
+			{ "off", NULL },
+			{ "on", NULL },
+			{ NULL, NULL },
+		},
+		"off"
+	},
+	{
+		"pzretro_use_puzzlescript_plus",
+		"PuzzleScript Plus Engine",
+		"Use the extended PuzzleScript Plus engine when running games, which contains a few additional features. Requires a restart.",
+		{
+			{ "off", NULL },
+			{ "on", NULL },
+			{ NULL, NULL },
+		},
+		"off"
+	},
+	{ NULL, NULL, NULL, {{0}}, NULL },
+};
+
+/*
+ ********************************
+ * Language Mapping
+ ********************************
+*/
+
+#ifndef HAVE_NO_LANGEXTRA
+struct retro_core_option_definition *option_defs_intl[RETRO_LANGUAGE_LAST] = {
+	option_defs_us, /* RETRO_LANGUAGE_ENGLISH */
+	NULL,           /* RETRO_LANGUAGE_JAPANESE */
+	NULL,           /* RETRO_LANGUAGE_FRENCH */
+	NULL,           /* RETRO_LANGUAGE_SPANISH */
+	NULL,           /* RETRO_LANGUAGE_GERMAN */
+	NULL,           /* RETRO_LANGUAGE_ITALIAN */
+	NULL,           /* RETRO_LANGUAGE_DUTCH */
+	NULL,           /* RETRO_LANGUAGE_PORTUGUESE_BRAZIL */
+	NULL,           /* RETRO_LANGUAGE_PORTUGUESE_PORTUGAL */
+	NULL,           /* RETRO_LANGUAGE_RUSSIAN */
+	NULL,           /* RETRO_LANGUAGE_KOREAN */
+	NULL,           /* RETRO_LANGUAGE_CHINESE_TRADITIONAL */
+	NULL,           /* RETRO_LANGUAGE_CHINESE_SIMPLIFIED */
+	NULL,           /* RETRO_LANGUAGE_ESPERANTO */
+	NULL,           /* RETRO_LANGUAGE_POLISH */
+	NULL,           /* RETRO_LANGUAGE_VIETNAMESE */
+	NULL,           /* RETRO_LANGUAGE_ARABIC */
+	NULL,           /* RETRO_LANGUAGE_GREEK */
+	NULL,           /* RETRO_LANGUAGE_TURKISH */
+};
+#endif
+
+/*
+ ********************************
+ * Functions
+ ********************************
+*/
+
+/* Handles configuration/setting of core options.
+ * Should be called as early as possible - ideally inside
+ * retro_set_environment(), and no later than retro_load_game()
+ * > We place the function body in the header to avoid the
+ *   necessity of adding more .c files (i.e. want this to
+ *   be as painless as possible for core devs)
+ */
+
+static INLINE void libretro_set_core_options(retro_environment_t environ_cb) {
+	unsigned version = 0;
+
+	if (!environ_cb) {
+		return;
+	}
+
+	if (environ_cb(RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION, &version) && (version >= 1)) {
+#ifndef HAVE_NO_LANGEXTRA
+		struct retro_core_options_intl core_options_intl;
+		unsigned language = 0;
+
+		core_options_intl.us    = option_defs_us;
+		core_options_intl.local = NULL;
+
+		if (environ_cb(RETRO_ENVIRONMENT_GET_LANGUAGE, &language) &&
+			 (language < RETRO_LANGUAGE_LAST) && (language != RETRO_LANGUAGE_ENGLISH))
+			core_options_intl.local = option_defs_intl[language];
+
+		environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL, &core_options_intl);
+#else
+		environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS, &option_defs_us);
+#endif
+	} else {
+		size_t i;
+		size_t num_options               = 0;
+		struct retro_variable *variables = NULL;
+		char **values_buf                = NULL;
+
+		/* Determine number of options */
+		while (true) {
+			if (option_defs_us[num_options].key) {
+				num_options++;
+			} else {
+				break;
+			}
+		}
+
+		/* Allocate arrays */
+		variables  = (struct retro_variable *)calloc(num_options + 1, sizeof(struct retro_variable));
+		values_buf = (char **)calloc(num_options, sizeof(char *));
+
+		if (!variables || !values_buf) {
+			goto error;
+		}
+
+		/* Copy parameters from option_defs_us array */
+		for (i = 0; i < num_options; i++) {
+			const char *key                        = option_defs_us[i].key;
+			const char *desc                       = option_defs_us[i].desc;
+			const char *default_value              = option_defs_us[i].default_value;
+			struct retro_core_option_value *values = option_defs_us[i].values;
+			size_t buf_len                         = 3;
+			size_t default_index                   = 0;
+
+			values_buf[i] = NULL;
+
+			if (desc) {
+				size_t num_values = 0;
+
+				/* Determine number of values */
+				while (true) {
+					if (values[num_values].value) {
+						/* Check if this is the default value */
+						if (default_value) {
+							if (strcmp(values[num_values].value, default_value) == 0) {
+								default_index = num_values;
+							}
+						}
+
+						buf_len += strlen(values[num_values].value);
+						num_values++;
+					} else {
+						break;
+					}
+				}
+
+				/* Build values string */
+				if (num_values > 0) {
+					size_t j;
+
+					buf_len += num_values - 1;
+					buf_len += strlen(desc);
+
+					values_buf[i] = (char *)calloc(buf_len, sizeof(char));
+					if (!values_buf[i])
+						goto error;
+
+					strcpy(values_buf[i], desc);
+					strcat(values_buf[i], "; ");
+
+					/* Default value goes first */
+					strcat(values_buf[i], values[default_index].value);
+
+					/* Add remaining values */
+					for (j = 0; j < num_values; j++) {
+						if (j != default_index) {
+							strcat(values_buf[i], "|");
+							strcat(values_buf[i], values[j].value);
+						}
+					}
+				}
+			}
+
+			variables[i].key   = key;
+			variables[i].value = values_buf[i];
+		}
+
+		/* Set variables */
+		environ_cb(RETRO_ENVIRONMENT_SET_VARIABLES, variables);
+
+error:
+
+		/* Clean up */
+		if (values_buf) {
+			for (i = 0; i < num_options; i++) {
+				if (values_buf[i]) {
+					free(values_buf[i]);
+					values_buf[i] = NULL;
+				}
+			}
+
+			free(values_buf);
+			values_buf = NULL;
+		}
+
+		if (variables) {
+			free(variables);
+			variables = NULL;
+		}
+	}
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // SRC_LIBRETRO_CORE_OPTIONS_H_

--- a/src/libretro_core_options_intl.h
+++ b/src/libretro_core_options_intl.h
@@ -1,0 +1,80 @@
+#ifndef LIBRETRO_CORE_OPTIONS_INTL_H__
+#define LIBRETRO_CORE_OPTIONS_INTL_H__
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1500 && _MSC_VER < 1900)
+/* https://support.microsoft.com/en-us/kb/980263 */
+#pragma execution_character_set("utf-8")
+#pragma warning(disable:4566)
+#endif
+
+#include <libretro.h>
+
+/*
+ ********************************
+ * VERSION: 1.3
+ ********************************
+ *
+ * - 1.3: Move translations to libretro_core_options_intl.h
+ *        - libretro_core_options_intl.h includes BOM and utf-8
+ *          fix for MSVC 2010-2013
+ *        - Added HAVE_NO_LANGEXTRA flag to disable translations
+ *          on platforms/compilers without BOM support
+ * - 1.2: Use core options v1 interface when
+ *        RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION is >= 1
+ *        (previously required RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION == 1)
+ * - 1.1: Support generation of core options v0 retro_core_option_value
+ *        arrays containing options with a single value
+ * - 1.0: First commit
+*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ ********************************
+ * Core Option Definitions
+ ********************************
+*/
+
+/* RETRO_LANGUAGE_JAPANESE */
+
+/* RETRO_LANGUAGE_FRENCH */
+
+/* RETRO_LANGUAGE_SPANISH */
+
+/* RETRO_LANGUAGE_GERMAN */
+
+/* RETRO_LANGUAGE_ITALIAN */
+
+/* RETRO_LANGUAGE_DUTCH */
+
+/* RETRO_LANGUAGE_PORTUGUESE_BRAZIL */
+
+/* RETRO_LANGUAGE_PORTUGUESE_PORTUGAL */
+
+/* RETRO_LANGUAGE_RUSSIAN */
+
+/* RETRO_LANGUAGE_KOREAN */
+
+/* RETRO_LANGUAGE_CHINESE_TRADITIONAL */
+
+/* RETRO_LANGUAGE_CHINESE_SIMPLIFIED */
+
+/* RETRO_LANGUAGE_ESPERANTO */
+
+/* RETRO_LANGUAGE_POLISH */
+
+/* RETRO_LANGUAGE_VIETNAMESE */
+
+/* RETRO_LANGUAGE_ARABIC */
+
+/* RETRO_LANGUAGE_GREEK */
+
+/* RETRO_LANGUAGE_TURKISH */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
This moves the variable system to `libretro_core_options()` which gives a couple new features...

- Allows translations of the core options
- Adds descriptions for them
- Backwards compatible with existing variables
