### PR TITLE
libretro: add webOS to Libretro CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -114,6 +114,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/emscripten-static.yml'
 
+  # webOS 32-bit (LGTV)
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/webos-make.yml'
+
 # Stages for building
 stages:
   - build-prepare
@@ -300,4 +304,10 @@ libretro-build-miyoo-arm32:
 libretro-build-emscripten:
   extends:
     - .libretro-emscripten-static-retroarch-master
+    - .core-defs
+
+# webOS
+libretro-build-webos-armv7a:
+  extends:
+    - .libretro-webos-armv7a-cmake
     - .core-defs


### PR DESCRIPTION
webOS core is now built by libretro infrastructure.